### PR TITLE
Fix Range Check Exception in RINOK()

### DIFF
--- a/sevenzip.pas
+++ b/sevenzip.pas
@@ -654,7 +654,7 @@ end;
 procedure RINOK(const hr: HRESULT);
 begin
   if hr <> S_OK then
-    raise Exception.Create(SysErrorMessage(hr));
+    raise Exception.Create(SysErrorMessage(Cardinal(hr)));
 end;
 
 procedure SetCardinalProperty(arch: I7zOutArchive; const name: UnicodeString; card: Cardinal);


### PR DESCRIPTION
Tested with Delphi 12.
HRESULT needs to be casted to Cardinal to avoid an ERangeCheckException.
