### PR TITLE
Fix for issue: https://github.com/geoffsmith82/d7zip/issues/15

### DIFF
--- a/sevenzip.pas
+++ b/sevenzip.pas
@@ -1867,7 +1867,7 @@ end;
 
 function T7zInArchive.GetItemAttributes(const index: integer): DWORD;
 begin
-  result := DWORD(GetItemProp(index, kpidAttributes));
+  result := DWORD(Int64(GetItemProp(index, kpidAttributes)));
 end;
 
 function T7zInArchive.GetItemIsFolder(const index: integer): boolean; stdcall;


### PR DESCRIPTION
-> delphi uses the wrong cast for Uint32.
-> Windows compressed folders create attributes > Maxint. This let the unpacking process fail!